### PR TITLE
Extend Makefile to provide description for targets using 'make help'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,29 @@
-.PHONY: all clean
+TEX_FILE = thesis
 
-all:
-	$(MAKE) clean
-	latex thesis.tex && \
-	biber thesis && \
-	latex thesis.tex && \
-	pdflatex thesis
+.PHONY: all
+all: build
 
-clean:
-	rm -f thesis.aux thesis.bbl thesis.bcf thesis.out
-	rm -f thesis.blg thesis.dvi thesis.log thesis.toc
-	rm -f thesis.run.xml
+.PHONY: latex
+latex: cleantemp ## Runs only latex and biber commands.
+	latex ${TEX_FILE}.tex && \
+	biber ${TEX_FILE} && \
+	latex ${TEX_FILE}.tex
 
+.PHONY: pdflatex
+pdflatex: ## Runs only the pdflatex command.
+	pdflatex ${TEX_FILE}
+
+.PHONY: build
+build: latex pdflatex ## Compiles the final PDF (latex & pdflatex).
+
+.PHONY: cleantemp
+cleantemp: ## Removes all temporary files created during the compiling process.
+	rm -f *.aux *.bbl *.bcf *.out *.blg *.dvi *.log *.toc *.run.xml
+
+.PHONY: clean
+clean: cleantemp ## Remove all created files created by the Makefile including the compiled PDF.
+	rm -f ${TEX_FILE}.pdf
+
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,24 @@ TEX_FILE = thesis
 all: build
 
 .PHONY: latex
-latex: cleantemp ## Runs only latex and biber commands.
+latex: cleantemp ## Run only latex and biber commands.
 	latex ${TEX_FILE}.tex && \
 	biber ${TEX_FILE} && \
 	latex ${TEX_FILE}.tex
 
 .PHONY: pdflatex
-pdflatex: ## Runs only the pdflatex command.
+pdflatex: ## Run only the pdflatex command.
 	pdflatex ${TEX_FILE}
 
 .PHONY: build
-build: latex pdflatex ## Compiles the final PDF (latex & pdflatex).
+build: latex pdflatex ## Compile the final PDF (latex & pdflatex).
 
 .PHONY: cleantemp
-cleantemp: ## Removes all temporary files created during the compiling process.
+cleantemp: ## Remove all temporary files created during the compiling process.
 	rm -f *.aux *.bbl *.bcf *.out *.blg *.dvi *.log *.toc *.run.xml
 
 .PHONY: clean
-clean: cleantemp ## Remove all created files created by the Makefile including the compiled PDF.
+clean: cleantemp ## Remove all created files including the compiled PDF.
 	rm -f ${TEX_FILE}.pdf
 
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # LaTeX Thesis Template
 
 ## How to build
-Use the `make all` command to output the compiled PDF.
+Use the `make` or `make build` command to compile the final PDF.
+For more information about the provided targets (tasks) use `make help`.
 
 ## Installation guide
 


### PR DESCRIPTION
Running `make help` will show now what targets are available with a short description of their function (see screenshot). Further documentation of the provided Makefile targets in the `README.md` is not necessary if a user can just run `make help` to get an overview.

<img width="968" alt="image" src="https://user-images.githubusercontent.com/9566732/108592921-c09d5580-7370-11eb-98fe-90b691d89aba.png">
