### PR TITLE
Fix page numbering and centralize translations

### DIFF
--- a/contents/example.tex
+++ b/contents/example.tex
@@ -1,4 +1,4 @@
-\chapter{Example Section}
+\chapter{Introduction}
 \label{chapter:example}
 
 {\textsl{General instructions:}} 
@@ -16,3 +16,5 @@ Please refer to the outlines at
 \label{cahpter:another-example}
 
 All chapters shall start on a right page!
+
+I am using an the \ac{FACR} here. The second usage of \ac{FACR} will only display the acronym itself.

--- a/osrthesis.sty
+++ b/osrthesis.sty
@@ -30,11 +30,19 @@
     \usepackage[UKenglish,ngerman]{babel}
     \usepackage[UKenglish,ngerman]{isodate}
     \selectlanguage{ngerman}
+
+    \newcommand{\appendixnamesingular}{Anhang}
+    \newcommand{\appendixnameplural}{Anhänge}
+    \newcommand{\referencesname}{Literaturverzeichnis}
 }{
     \usepackage[ngerman,UKenglish]{babel}
     \usepackage[ngerman,UKenglish]{isodate}
     \selectlanguage{UKenglish}
     \cleanlookdateon
+
+    \newcommand{\appendixnamesingular}{Appendix}
+    \newcommand{\appendixnameplural}{Appendices}
+    \newcommand{\referencesname}{References}
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -50,7 +58,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% appendix package configuration
-\renewcommand{\appendixname}{Appendix}
+\renewcommand{\appendixname}{\appendixnamesingular}
 
 %% fancyhdr package configuration
 \pagestyle{fancy}

--- a/thesis.tex
+++ b/thesis.tex
@@ -30,7 +30,7 @@
 
 %% Make the page numbering use Roman numerals.  Start counting after title
 %% page.
-\renewcommand{\thepage}{\roman{page}}
+\pagenumbering{roman}
 \setcounter{page}{1}
 
 %% Remove the page breaks between chapters
@@ -90,11 +90,8 @@ International license (CC BY 4.0), see
 
 %%%%%%%%%%%%%%%%% MAIN SECTION %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%% Note: Include these after the first \chapter declaration in the main 
-%% section. They should not be used after that.
-\renewcommand{\thepage}{\arabic{page}}
-\setcounter{page}{1}
-%%
+\cleardoublepage
+\pagenumbering{arabic}
 
 \input contents/example.tex
 
@@ -106,25 +103,16 @@ International license (CC BY 4.0), see
 
 \renewcommand{\setthesection}{\Alph{section}}
 \renewcommand{\thesection}{\Alph{section}}
-\fancyhead[RE]{\footnotesize{Appendix \thesection: \rightmark}\normalfont}
+\fancyhead[RE]{\footnotesize{\appendixnamesingular\ \thesection: \rightmark}\normalfont}
 \pagebreak
-\iftoggle{thesis_in_german} {
-    \addcontentsline{toc}{chapter}{Anhänge}
-}{
-    \addcontentsline{toc}{chapter}{Appendices}
-}
+\addcontentsline{toc}{chapter}{\appendixnameplural}
 \input contents/appendices.tex
 \end{subappendices}
 \fancyhead[RE]{\footnotesize{\rightmark}\normalfont}
 
-\clearpage\phantomsection %% Ensure the ToC entry for References has right pg#
-\iftoggle{thesis_in_german} {
-    \renewcommand\bibname{Literaturverzeichnis}
-    \addcontentsline{toc}{chapter}{Literaturverzeichnis}
-}{
-    \renewcommand\bibname{References}
-    \addcontentsline{toc}{chapter}{References}
-}
+\cleardoublepage
+\renewcommand\bibname{\referencesname}
+\addcontentsline{toc}{chapter}{\referencesname}
 \printbibliography
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
- Use simpler command to adjust the page numbering. This also fixes an issue that the acronyms are having the page number `1` instead of the first main chapter.
- Centralize translations in one place. This also fixes some missing german translations.