### PR TITLE
More fixes and improvements

### DIFF
--- a/myconfiguration.sty
+++ b/myconfiguration.sty
@@ -4,4 +4,4 @@
 \newcommand\thesissubtitle{Thesis Subtitle}
 \newcommand\thesissubmissiondate{2015-07-09}
 \newcommand\thesissubmissioncity{Erlangen}
-\newcommand\thesislevel{Bachelor} % Change to 'Master' if applicable
+\newcommand\thesistype{Bachelor thesis}

--- a/osrthesis.sty
+++ b/osrthesis.sty
@@ -9,7 +9,7 @@
 \usepackage[bookmarks=true,pdfborder={0 0 0}]{hyperref} 
 \usepackage{fancyhdr}
 \usepackage[titletoc,header,title]{appendix}
-\usepackage{caption} 
+\usepackage{caption}
 \usepackage{titlesec}
 \usepackage{parskip}
 \usepackage{etoolbox}

--- a/osrthesis.sty
+++ b/osrthesis.sty
@@ -14,6 +14,7 @@
 \usepackage{parskip}
 \usepackage{etoolbox}
 \usepackage{acronym}
+\usepackage{csquotes}
 
 
 %% Set up an English/German language toggle
@@ -27,17 +28,17 @@
 
 %% Determine which date setting and language to use by default
 \iftoggle{thesis_in_german} {
-    \usepackage[UKenglish,ngerman]{babel}
-    \usepackage[UKenglish,ngerman]{isodate}
+    \usepackage[british,ngerman]{babel}
+    \usepackage[british,ngerman]{isodate}
     \selectlanguage{ngerman}
 
     \newcommand{\appendixnamesingular}{Anhang}
     \newcommand{\appendixnameplural}{Anhänge}
     \newcommand{\referencesname}{Literaturverzeichnis}
 }{
-    \usepackage[ngerman,UKenglish]{babel}
-    \usepackage[ngerman,UKenglish]{isodate}
-    \selectlanguage{UKenglish}
+    \usepackage[ngerman,british]{babel}
+    \usepackage[ngerman,british]{isodate}
+    \selectlanguage{british}
     \cleanlookdateon
 
     \newcommand{\appendixnamesingular}{Appendix}
@@ -78,8 +79,9 @@
 
 
 %% hyperref package configuration
-\hypersetup{pdftitle={\thesistitle},
-            pdfauthor={\thesisauthorsurname}
+\hypersetup{
+    pdftitle={\thesistitle},
+    pdfauthor={\thesisauthorsurname}
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -91,40 +93,40 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \makeatletter
 \renewcommand\maketitle{%
-        \begin{titlepage}
-        \thispagestyle{empty}
-        \Large Friedrich-Alexander-Universität Erlangen-Nürnberg
-        \vspace{0.03in} \\
-        \Large Technische Fakultät, Department Informatik \\
-        %
- 	\vfill
-        \Large \MakeUppercase{\thesisauthorgivenname\ \thesisauthorsurname}
-        \vspace{0.1in} \\
-        \Large \MakeUppercase{\thesislevel\ thesis} \\	
-        %
- 	\\
-        \\
-	\LARGE\textbf{\MakeUppercase{\thesistitle}} \\
-        \\
-	\Large\textbf{\MakeUppercase{\thesissubtitle}} \\
-        %
-        \\
-        \\
+    \begin{titlepage}
+    \thispagestyle{empty}
+    \Large Friedrich-Alexander-Universität Erlangen-Nürnberg
+    \vspace{0.03in} \\
+    \Large Technische Fakultät, Department Informatik \\
+    %
+    \vfill
+    \Large \MakeUppercase{\thesisauthorgivenname\ \thesisauthorsurname}
+    \vspace{0.1in} \\
+    \Large \MakeUppercase{\thesislevel\ thesis} \\
+    %
+    \\
+    \\
+    \LARGE\textbf{\MakeUppercase{\thesistitle}} \\
+    \\
+    \Large\textbf{\MakeUppercase{\thesissubtitle}} \\
+    %
+    \\
+    \\
 \iftoggle{thesis_in_german} {
-	\normalsize Eingereicht am \printdate{\thesissubmissiondate}  \\ 
+    \normalsize Eingereicht am \printdate{\thesissubmissiondate}  \\
 }{
-	\normalsize Submitted on \printdate{\thesissubmissiondate}  \\ 
+    \normalsize Submitted on \printdate{\thesissubmissiondate}  \\
 }
-        %
- 	\vfill
+    %
+    \vfill
 \iftoggle{thesis_in_german} {
-Betreuer:
+    Betreuer:
 }{
-Supervisor:
+    Supervisor:
 }
-Prof. Dr. Dirk Riehle, M.B.A.\\Professur für Open-Source-Software\\Department Informatik, Technische Fakultät\\Friedrich-Alexander-Universität Erlangen-Nürnberg
-        %
-        \end{titlepage}
+    Prof. Dr. Dirk Riehle, M.B.A.\\Professur für Open-Source-Software\\Department Informatik, Technische Fakultät\\Friedrich-Alexander-Universität Erlangen-Nürnberg
+    %
+    \end{titlepage}
 }
 \makeatother
 

--- a/osrthesis.sty
+++ b/osrthesis.sty
@@ -102,7 +102,7 @@
     \vfill
     \Large \MakeUppercase{\thesisauthorgivenname\ \thesisauthorsurname}
     \vspace{0.1in} \\
-    \Large \MakeUppercase{\thesislevel\ thesis} \\
+    \Large \MakeUppercase{\thesistype} \\
     %
     \\
     \\

--- a/thesis.tex
+++ b/thesis.tex
@@ -11,6 +11,9 @@
 \usepackage{myconfiguration,osrthesis}
 \usepackage[backend=biber,style=apa]{biblatex}
 
+\DeclareLanguageMapping{ngerman}{ngerman-apa}
+\DeclareLanguageMapping{british}{british-apa}
+
 \addbibresource[datatype=bibtex]{mybibliography.bib}
 
 \title{\thesistitle}

--- a/thesis.tex
+++ b/thesis.tex
@@ -11,10 +11,6 @@
 \usepackage{myconfiguration,osrthesis}
 \usepackage[backend=biber,style=apa]{biblatex}
 
-\DeclareLanguageMapping{ngerman}{ngerman-apa}
-\DeclareLanguageMapping{UKEnglish}{british-apa}
-\DeclareLanguageMapping{english}{british-apa}
-
 \addbibresource[datatype=bibtex]{mybibliography.bib}
 
 \title{\thesistitle}
@@ -69,18 +65,18 @@ International license (CC BY 4.0), see
 %% Re-install the page breaks between chapters
 \makeatletter
 \renewcommand\chapter{\if@openright\cleardoublepage\else\clearpage\fi
-   \thispagestyle{plain}%
-   \global\@topnum\z@
-   \@afterindentfalse
-   \secdef\@chapter\@schapter}
+  \thispagestyle{plain}%
+  \global\@topnum\z@
+  \@afterindentfalse
+  \secdef\@chapter\@schapter}
 \makeatother
 
 \chapter*{Abstract}\label{chapter:abstract}
 \input contents/abstract.tex
 
 \iftoggle{thesis_in_german} {
-    \chapter*{Zusammenfassung}\label{chapter:zusammenfassung}
-    \input contents/zusammenfassung.tex
+  \chapter*{Zusammenfassung}\label{chapter:zusammenfassung}
+  \input contents/zusammenfassung.tex
 }
 
 \tableofcontents


### PR DESCRIPTION
-  Make thesis type fully adjustable and therefore translateable.
- Add `csquotes` package to fix following warning:
  > 'babel/polyglossia' detected but 'csquotes' missing.
(biblatex)	Loading 'csquotes' recommended.
- Use `british` instead of `UKenglish` as a language key. This fixes following warning:
  > File 'UKenglish-apa.lbx' not found!
(biblatex)	Ignoring mapping 'UKenglish' -> 'UKenglish-apa'.