### PR TITLE
Set font encoding to T1

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -8,6 +8,7 @@
 
 \documentclass[12pt,a4paper,twoside,openright]{report}
 \usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
 \usepackage{myconfiguration,osrthesis}
 \usepackage[backend=biber,style=apa]{biblatex}
 


### PR DESCRIPTION
This is especially useful for a german thesis because german umlaute will now be outputted as a single glyph. Therefore it results in better hyphenation and better copy and paste from the final pdf. Also, see this StackOverflow answer for a detailed explanation: https://tex.stackexchange.com/a/677