### PR TITLE
Fix chapter starting not on right page

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -28,7 +28,6 @@
 
 %%%%%%%%%%%%%%%%% PREFIX SECTION %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \pagenumbering{roman}
-\setcounter{page}{1}
 \headerstyleprefixsection
 
 %% Remove the page breaks between chapters


### PR DESCRIPTION
Currently, all chapters do start on the left page, because the page number is reset to `1` on the second page. 