### PR TITLE
deleting tokenize from thesis.tex and osrthesis.sty

### DIFF
--- a/osrthesis.sty
+++ b/osrthesis.sty
@@ -20,7 +20,7 @@
 
 %% Determine which date setting and language to use by default
 \usepackage{ifthen} 
-\ifthenelse{\equal{\detokenize{\thesislanguage}}{\detokenize{German}}}
+\ifthenelse{\equal{\thesislanguage}{German}}
     { % true
         \usepackage[british,ngerman]{babel} % last entry as primary language
         \usepackage[british,ngerman]{isodate}

--- a/thesis.tex
+++ b/thesis.tex
@@ -77,7 +77,7 @@ International license (CC BY 4.0), see
 \chapter*{Abstract}\label{chapter:abstract}
 \input contents/abstract.tex
 
-\ifthenelse{\equal{\detokenize{\thesislanguage}}{\detokenize{German}}}
+\ifthenelse{\equal{\thesislanguage}{German}}
   { % true
     \chapter*{Zusammenfassung}\label{chapter:zusammenfassung}
     \input contents/zusammenfassung.tex


### PR DESCRIPTION
fixes #16 

successfully tested on:
- Windows Subsystem Linux (Ubuntu 20.04) using pdfTeX 3.14159265-2.6-1.40.20 (TeX Live 2019/Debian)
- Windows 10 using pdfTeX, Version 3.141592653-2.6-1.40.24 (MiKTeX 21.12)

thesis-example does not change. So no new example is included.